### PR TITLE
Remove confusing piping from "roll your own socket.io" example

### DIFF
--- a/example/roll_your_own_socketio/main.js
+++ b/example/roll_your_own_socketio/main.js
@@ -3,7 +3,7 @@ var emitStream = require('emit-stream');
 var JSONStream = require('JSONStream');
 
 var parser = JSONStream.parse([true]);
-var stream = parser.pipe(shoe('/sock')).pipe(parser);
+var stream = shoe('/sock').pipe(parser);
 var ev = emitStream(stream);
 
 ev.on('lower', function (msg) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -948,7 +948,7 @@ var emitStream = require('emit-stream');
 var JSONStream = require('JSONStream');
 
 var parser = JSONStream.parse([true]);
-var stream = parser.pipe(shoe('/sock')).pipe(parser);
+var stream = shoe('/sock').pipe(parser);
 var ev = emitStream(stream);
 
 ev.on('lower', function (msg) {


### PR DESCRIPTION
The piping from the client-side parser back to the server seems to be superfluous (as the server doesn't read from the socket, unless it's something to do with 'end') and is very confusing to people trying to understand what is going on in this example. Trust me on that ;)

If it's not superfluous I would be very grateful if you could explain it in the surrounding text...
