### PR TITLE
Reworded ambiguous "they"

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -109,8 +109,8 @@ server.listen(8000);
 
 Here `.pipe()` takes care of listening for `'data'` and `'end'` events from the
 `fs.createReadStream()`. This code is not only cleaner, but now the `data.txt`
-file will be written to clients one chunk at a time immediately as they are
-received from the disk.
+file will be written to clients one chunk at a time immediately as each chunk
+is received from the disk.
 
 Using `.pipe()` has other benefits too, like handling backpressure automatically
 so that node won't buffer chunks into memory needlessly when the remote client


### PR DESCRIPTION
Made the following sentence a little bit more clear by replacing the words "they are" with "each chunk is". It was unclear what "they" was referring to, and if it was referring to each singular chunk, it was a grammar error. This avoids all confusion.

I made sure to keep existing line-length conventions. 

![image](https://cloud.githubusercontent.com/assets/7017045/5638784/1c8c1e2e-95c1-11e4-8afb-e5a5627add47.png)

![image](https://cloud.githubusercontent.com/assets/7017045/5638788/2751d862-95c1-11e4-9656-3c11981f3694.png)
