### PR TITLE
Finished line that wandered off midsentence

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -499,7 +499,9 @@ If you want to wait for the buffer to empty again, listen for a `'drain'` event.
 
 ## transform
 
-Transform streams are
+Transform streams are a certain type of duplex stream (both readable and writable).
+The distinction is that in Transform streams, the output is in some way calculated
+from the input. 
 
 You might also hear transform streams referred to as "through streams".
 


### PR DESCRIPTION
As noted in https://github.com/substack/stream-handbook/issues/62 this sentence mysteriously ends midway through. I led it to a logical conclusion. 

I maintained line length standards, and referenced my answer against the official Node docs to ensure accuracy. 
Original:
![image](https://cloud.githubusercontent.com/assets/7017045/5659235/bedc77e8-96c3-11e4-8a6a-f003b3c707e1.png)

Updated:
![image](https://cloud.githubusercontent.com/assets/7017045/5659236/c7e494f6-96c3-11e4-806e-7c95bab6f6b4.png)