### PR TITLE
Fix the readable stream unshift example

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -394,7 +394,7 @@ process.stdin.on('readable', function () {
             return;
         }
     }
-    process.stdin.unshift(buf);
+    console.dir(buf.toString());
 });
 ```
 


### PR DESCRIPTION
It crashed on the last "process.stdin.unshift(buf);" if there wasn't a new line. For example, "printf 'Hello, World!' | node program.js". The error was "RangeError: Maximum call stack size exceeded".