### PR TITLE
Fix error when there is last line without newline symbol

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -394,7 +394,7 @@ process.stdin.on('readable', function () {
             return;
         }
     }
-    process.stdin.unshift(buf);
+    console.dir(buf.toString());
 });
 ```
 


### PR DESCRIPTION
Fix error described in issue #95 
`process.stdin.unshift` replaced by `console.dir`